### PR TITLE
fix: handle unbound PYTHONPATH in nix run wrapper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,7 @@
                             fi
                             
                             # Launch the application from the writable copy
-                            PYTHONPATH="$workdir/python:$PYTHONPATH"
+                            PYTHONPATH="$workdir/python${PYTHONPATH:+:$PYTHONPATH}"
                             export PYTHONPATH
                             cd "$workdir"
                             exec python -m pokecon "$@"


### PR DESCRIPTION
## Problem
`nix run .#pokecon` fails with `line 49: PYTHONPATH: unbound variable` when `PYTHONPATH` is not set in the environment.

## Root Cause
The wrapper script uses `set -u` (nounset), which treats unset variables as errors. The line:
```bash
PYTHONPATH="/python:"
```
…expands `` when it is unset, triggering the error.

## Fix
Use `` syntax, which safely expands to nothing when `PYTHONPATH` is unset/empty, and to `:` when it is set.

## Verification
- Before: `PYTHONPATH="/python:"` → `unbound variable`
- After: `PYTHONPATH="/python"` → safe in all cases