### PR TITLE
fix(flake): add missing Nix string escape for PYTHONPATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,7 @@
                             fi
                             
                             # Launch the application from the writable copy
-                            PYTHONPATH="$workdir/python${PYTHONPATH:+:$PYTHONPATH}"
+                            PYTHONPATH="$workdir/python''${PYTHONPATH:+:$PYTHONPATH}"
                             export PYTHONPATH
                             cd "$workdir"
                             exec python -m pokecon "$@"


### PR DESCRIPTION
## Problem
PR #22 attempted to fix the `PYTHONPATH: unbound variable` error by using bash-safe `${PYTHONPATH:+:$PYTHONPATH}` syntax. However, it missed the Nix string escape, so Nix still consumed the `${}` braces at evaluation time.

## Root Cause
In Nix `''`-quoted (indented) strings, `${` is interpreted as Nix expression interpolation. To emit a literal `${` for bash, you must write `''${`.

Without the escape, Nix produced:
```bash
PYTHONPATH="$workdir/pythonPYTHONPATH:+:$PYTHONPATH"
```
…which still fails under `set -u` because the bare `$PYTHONPATH` is unbound.

## Fix
Add the missing `''` prefix before `${`:
```nix
PYTHONPATH="$workdir/python''${PYTHONPATH:+:$PYTHONPATH}"
```

All other PYTHONPATH uses in this flake (lines 204, 241, 499, 505) already use `''${` correctly — only the `pokeconApp` (default app) was missing it.

## Verification
- The generated `/nix/store/.../bin/pokecon` now contains the correct bash `${PYTHONPATH:+:$PYTHONPATH}` syntax
- Works when PYTHONPATH is unset (expands to nothing) and when set (prepends `:$PYTHONPATH`)